### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,7 @@
 name: ci
+permissions:
+  contents: read
+  metadata: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/openkcm/extauthz/security/code-scanning/2](https://github.com/openkcm/extauthz/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `metadata: read` for generating build metadata.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
