### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openkcm/extauthz/security/code-scanning/1](https://github.com/openkcm/extauthz/security/code-scanning/1)

To address the issue, we will add a `permissions` block to the root of the workflow file. This block will explicitly define the least privileges required for the workflow to function correctly. Based on the provided workflow, it appears that the workflow primarily checks compliance and does not require write access. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
