### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Git
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [ closed ]


### PR DESCRIPTION
Potential fix for [https://github.com/openkcm/extauthz/security/code-scanning/4](https://github.com/openkcm/extauthz/security/code-scanning/4)

To fix the issue, add a `permissions` block to the root of the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow delegates its functionality to another workflow, the permissions required are likely minimal. A good starting point is to set `contents: read`, which allows the workflow to read repository contents without granting write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
