### PR TITLE
fix: chart template, chart version and API group

### DIFF
--- a/charts/extauthz/Chart.yaml
+++ b/charts/extauthz/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.3.0"
+appVersion: "v0.1.2"

--- a/charts/extauthz/templates/configmap.yaml
+++ b/charts/extauthz/templates/configmap.yaml
@@ -53,13 +53,13 @@ data:
     jwt:
       operationMode: {{ .Values.config.jwtOperationMode | default "default" }}
       k8sProviders:
-        apiGroup: {{ .Values.config.jwtk8sProvidersAPIGroup | default "/apis/gateway.extensions.security.cloud.sap/v1alpha1" }}
+        apiGroup: {{ .Values.config.jwtk8sProvidersAPIGroup | default "/apis/gateway.extensions.envoyproxy.io/v1alpha1" }}
         name: {{ .Values.config.jwtk8sProvidersName | default "jwtproviders" }}
         namespace: {{ .Values.config.jwtk8sProvidersNamespace | default "default" }}
 
     # Client Data handling
     clientData:
-      publicKeyAddress: {{ .Values.config.clientData.withRegion | default ":5555" }}
-      signingKeyRefreshIntervalS: {{ .Values.config.clientData.withRegion | default 21600 }}
+      publicKeyAddress: {{ .Values.config.clientData.publicKeyAddress | default ":5555" }}
+      signingKeyRefreshIntervalS: {{ .Values.config.clientData.signingKeyRefreshIntervalS | default 21600 }}
       withRegion: {{ .Values.config.clientData.withRegion | default false }}
       withType: {{ .Values.config.clientData.withType | default false }}

--- a/charts/extauthz/values.yaml
+++ b/charts/extauthz/values.yaml
@@ -225,7 +225,7 @@ config:
   policyPath: /etc/extauthz-policies
   mtlsTrustedSubjectsYaml: /etc/extauthz-mtls/trustedSubjects.yaml
   # jwtOperationMode: default
-  # jwtk8sProvidersAPIGroup: /apis/gateway.extensions.security.cloud.sap/v1alpha1
+  # jwtk8sProvidersAPIGroup: /apis/gateway.extensions.envoyproxy.io/v1alpha1
   # jwtk8sProvidersName: jwtproviders
   # jwtk8sProvidersNamespace: default
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -29,7 +29,7 @@ mtls:
 jwt:
   operationMode: default # one of: default, sapias
   k8sProviders:
-    apiGroup: "/apis/gateway.extensions.security.cloud.sap/v1alpha1"
+    apiGroup: "/apis/gateway.extensions.envoyproxy.io/v1alpha1"
     name: "jwtproviders"
     namespace: "default"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
- The configmap used the wrong values
- The versions in `Chart.yaml` didn't match the tags
- The API group for the JWTProvider was wrong
```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
NONE
```
