### PR TITLE
Various fixes

### DIFF
--- a/charts/extauthz/Chart.yaml
+++ b/charts/extauthz/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.2"
+appVersion: "v0.2.3"

--- a/charts/extauthz/templates/clusterrole.yaml
+++ b/charts/extauthz/templates/clusterrole.yaml
@@ -4,6 +4,6 @@ kind: ClusterRole
 metadata:
   name: {{ include "extauthz.serviceAccountName" . }}-jwtprovider-clusterrole
 rules:
-- apiGroups: [ "{{ .Values.config.jwtk8sProvidersAPIGroup | default "/apis/gateway.extensions.envoyproxy.io/v1alpha1" }}" ]
+- apiGroups: [ "{{ .Values.config.jwtk8sProvidersAPIGroup | default "gateway.extensions.envoyproxy.io" }}" ]
   resources: [ "{{ .Values.config.jwtk8sProvidersName | default "jwtproviders" }}" ]
   verbs: ["get", "list"]

--- a/charts/extauthz/templates/configmap.yaml
+++ b/charts/extauthz/templates/configmap.yaml
@@ -53,7 +53,8 @@ data:
     jwt:
       operationMode: {{ .Values.config.jwtOperationMode | default "default" }}
       k8sProviders:
-        apiGroup: {{ .Values.config.jwtk8sProvidersAPIGroup | default "/apis/gateway.extensions.envoyproxy.io/v1alpha1" }}
+        apiGroup: {{ .Values.config.jwtk8sProvidersAPIGroup | default "gateway.extensions.envoyproxy.io" }}
+        apiVersion: {{ .Values.config.jwtk8sProvidersAPIVersion | default "v1alpha1" }}
         name: {{ .Values.config.jwtk8sProvidersName | default "jwtproviders" }}
         namespace: {{ .Values.config.jwtk8sProvidersNamespace | default "default" }}
 

--- a/charts/extauthz/values.yaml
+++ b/charts/extauthz/values.yaml
@@ -225,7 +225,8 @@ config:
   policyPath: /etc/extauthz-policies
   mtlsTrustedSubjectsYaml: /etc/extauthz-mtls/trustedSubjects.yaml
   # jwtOperationMode: default
-  # jwtk8sProvidersAPIGroup: /apis/gateway.extensions.envoyproxy.io/v1alpha1
+  # jwtk8sProvidersAPIGroup: gateway.extensions.envoyproxy.io
+  # jwtk8sProvidersAPIVersion: v1alpha1
   # jwtk8sProvidersName: jwtproviders
   # jwtk8sProvidersNamespace: default
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -29,7 +29,8 @@ mtls:
 jwt:
   operationMode: default # one of: default, sapias
   k8sProviders:
-    apiGroup: "/apis/gateway.extensions.envoyproxy.io/v1alpha1"
+    apiGroup: "gateway.extensions.envoyproxy.io"
+    apiVersion: "v1alpha1"
     name: "jwtproviders"
     namespace: "default"
 

--- a/internal/business/extauthz.go
+++ b/internal/business/extauthz.go
@@ -39,6 +39,7 @@ func createExtAuthZServer(ctx context.Context, cfg *config.Config) (*extauthz.Se
 		jwthandler.WithOperationMode(jwtOperationMode),
 		jwthandler.WithK8sJWTProviders(true,
 			cfg.JWT.K8sProviders.APIGroup,
+			cfg.JWT.K8sProviders.APIVersion,
 			cfg.JWT.K8sProviders.Name,
 			cfg.JWT.K8sProviders.Namespace,
 		),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,9 +53,10 @@ type JWT struct {
 }
 
 type K8sProviders struct {
-	APIGroup  string
-	Name      string
-	Namespace string
+	APIGroup   string // e.g. "gateway.extensions.envoyproxy.io"
+	APIVersion string // e.g. "v1alpha1"
+	Name       string // e.g. "jwtproviders"
+	Namespace  string // e.g. "default"
 }
 
 // ClientData defines the information passed as header to consuming backend services.

--- a/internal/jwthandler/handler_test.go
+++ b/internal/jwthandler/handler_test.go
@@ -90,7 +90,7 @@ func TestNewHandler(t *testing.T) {
 		}, {
 			name: "with k8s providers",
 			opts: []HandlerOption{
-				WithK8sJWTProviders(true, "crdAPIGroup", "crdName", "crdNameSpace"),
+				WithK8sJWTProviders(true, "crdAPIGroup", "crdAPIVersion", "crdName", "crdNameSpace"),
 			},
 			checkFunc: func(h *Handler) error {
 				if !h.k8sJWTProvidersEnabled {
@@ -538,7 +538,7 @@ func TestK8sJWTProviderFor(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
-			hdl, err := NewHandler(WithK8sJWTProviders(true, "crdAPIGroup", "crdName", "crdNameSpace"))
+			hdl, err := NewHandler(WithK8sJWTProviders(true, "crdAPIGroup", "crdAPIVersion", "crdName", "crdNameSpace"))
 			if err != nil {
 				t.Fatalf("could not create handler: %s", err)
 			}

--- a/internal/jwthandler/provider.go
+++ b/internal/jwthandler/provider.go
@@ -219,6 +219,7 @@ func (provider *Provider) introspect(ctx context.Context, rawToken string) (intr
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+rawToken)
 	q := req.URL.Query()
 	q.Set("token", rawToken)
 	req.URL.RawQuery = q.Encode()
@@ -227,7 +228,6 @@ func (provider *Provider) introspect(ctx context.Context, rawToken string) (intr
 	if err != nil {
 		return introspection{}, fmt.Errorf("executing http request: %w", err)
 	}
-
 	defer resp.Body.Close()
 
 	var intr introspection


### PR DESCRIPTION
- Do not log JWT tokens (fixes #36)
- Set the `Authorization` header during introspection
- Properly handle k8s API group and version
  - group is used in cluster role
  - group/version is used in rest client