### PR TITLE
fix: enforce CSRF checks

### DIFF
--- a/internal/extauthz/check_session.go
+++ b/internal/extauthz/check_session.go
@@ -52,11 +52,10 @@ func (srv *Server) checkSession(ctx context.Context, sessionCookie *http.Cookie,
 		csrfTokenHash := sha256.New().Sum(srv.csrfSecret)
 
 		slogctx.Debug(ctx, "CSRF token is not valid", "tokenHash", tokenHash[:5], "cookieHash", cookieHash[:5], "csrfTokenHash", csrfTokenHash[:5])
-		// TODO: remove comment when CSRF validation is well tested
-		// return checkResult{
-		// 	is:   UNAUTHENTICATED,
-		// 	info: "CSRF token is not valid",
-		// }
+		return checkResult{
+			is:   UNAUTHENTICATED,
+			info: "CSRF token is not valid",
+		}
 	}
 
 	// prepare the result

--- a/internal/extauthz/check_session_test.go
+++ b/internal/extauthz/check_session_test.go
@@ -71,41 +71,38 @@ func TestCheckSession(t *testing.T) {
 			},
 			expectedResult: checkResult{is: UNAUTHENTICATED},
 		}, {
-			// 	// TODO: remove comment when CSRF validation is well tested
-			// 	name:      "Session ID doesn't match the CSRF token",
-			// 	cookie:    &http.Cookie{Name: "session", Value: "malformed session id"},
-			// 	method:    "GET",
-			// 	host:      "our.service.com",
-			// 	path:      "/foo/bar",
-			// 	csrfToken: csrfToken,
-			// 	setupMocks: func(sm *MockSessionManager) {
-			//nolint:dupword
-			// 		sm.On("GetSession", mock.Anything, mock.Anything, "", "").
-			// 			Return(&session.Session{
-			// 				Valid:   true,
-			// 				Subject: "me",
-			// 				Issuer:  "https://127.0.0.1:8443",
-			// 			}, nil)
-			// 	},
-			// 	expectedResult: checkResult{is: UNAUTHENTICATED},
-			// }, {
-			// 	name:      "Malformed CSRF token",
-			// 	cookie:    &http.Cookie{Name: "session", Value: sessionID},
-			// 	method:    "GET",
-			// 	host:      "our.service.com",
-			// 	path:      "/foo/bar",
-			// 	csrfToken: "malformed csrf token",
-			// 	setupMocks: func(sm *MockSessionManager) {
-			//nolint:dupword
-			// 		sm.On("GetSession", mock.Anything, mock.Anything, "", "").
-			// 			Return(&session.Session{
-			// 				Valid:   true,
-			// 				Subject: "me",
-			// 				Issuer:  "https://127.0.0.1:8443",
-			// 			}, nil)
-			// 	},
-			// 	expectedResult: checkResult{is: UNAUTHENTICATED},
-			// }, {
+			name:      "Session ID doesn't match the CSRF token",
+			cookie:    &http.Cookie{Name: "session", Value: "malformed session id"},
+			method:    "GET",
+			host:      "our.service.com",
+			path:      "/foo/bar",
+			csrfToken: csrfToken,
+			setupMocks: func(sm *MockSessionManager) {
+				sm.On("GetSession", mock.Anything, mock.Anything, "", "").
+					Return(&session.Session{
+						Valid:   true,
+						Subject: "me",
+						Issuer:  "https://127.0.0.1:8443",
+					}, nil)
+			},
+			expectedResult: checkResult{is: UNAUTHENTICATED},
+		}, {
+			name:      "Malformed CSRF token",
+			cookie:    &http.Cookie{Name: "session", Value: sessionID},
+			method:    "GET",
+			host:      "our.service.com",
+			path:      "/foo/bar",
+			csrfToken: "malformed csrf token",
+			setupMocks: func(sm *MockSessionManager) {
+				sm.On("GetSession", mock.Anything, mock.Anything, "", "").
+					Return(&session.Session{
+						Valid:   true,
+						Subject: "me",
+						Issuer:  "https://127.0.0.1:8443",
+					}, nil)
+			},
+			expectedResult: checkResult{is: UNAUTHENTICATED},
+		}, {
 			name:      "Policy deny",
 			cookie:    &http.Cookie{Name: "session", Value: sessionID},
 			csrfToken: csrfToken,

--- a/internal/extauthz/check_test.go
+++ b/internal/extauthz/check_test.go
@@ -240,53 +240,52 @@ func TestCheck(t *testing.T) {
 			wantError: false,
 			wantCode:  code.Code_PERMISSION_DENIED,
 		}, {
-			// 	// TODO: remove comment when CSRF validation is well tested
-			// 	name:         "with malformed CSRF token",
-			// 	featureGates: defaultFeatureGates,
-			// 	request: &envoy_auth.CheckRequest{
-			// 		Attributes: &envoy_auth.AttributeContext{
-			// 			Request: &envoy_auth.AttributeContext_Request{
-			// 				Http: &envoy_auth.AttributeContext_HttpRequest{
-			// 					Method:  "GET",
-			// 					Host:    "our.service.com",
-			// 					Path:    "/cmk/v1/myTenantID/bar",
-			// 					Headers: map[string]string{"cookie": "__Host-Http-SESSION=" + sessionID, HeaderCSRFToken: "malformed CSRF token"}}}}},
-			// 	setupMocks: func(msm *MockSessionManager) {
-			// 		msm.On("GetSession", mock.Anything, "mySessionID", "myTenantID", mock.Anything).
-			// 			Return(&session.Session{
-			// 				Valid:      true,
-			// 				Subject:    "mySessionMe",
-			// 				Issuer:     "https://127.0.0.1:8443",
-			// 				GivenName:  "Chris",
-			// 				FamilyName: "Burkert",
-			// 			}, nil)
-			// 	},
-			// 	wantError: false,
-			// 	wantCode:  rpc.UNAUTHENTICATED,
-			// }, {
-			// 	name:         "with malformed cookie",
-			// 	featureGates: defaultFeatureGates,
-			// 	request: &envoy_auth.CheckRequest{
-			// 		Attributes: &envoy_auth.AttributeContext{
-			// 			Request: &envoy_auth.AttributeContext_Request{
-			// 				Http: &envoy_auth.AttributeContext_HttpRequest{
-			// 					Method:  "GET",
-			// 					Host:    "our.service.com",
-			// 					Path:    "/cmk/v1/myTenantID/bar",
-			// 					Headers: map[string]string{"cookie": "__Host-Http-SESSION=" + "malformedSessionID", HeaderCSRFToken: "malformed CSRF token"}}}}},
-			// 	setupMocks: func(msm *MockSessionManager) {
-			// 		msm.On("GetSession", mock.Anything, "malformedSessionID", "myTenantID", mock.Anything).
-			// 			Return(&session.Session{
-			// 				Valid:      true,
-			// 				Subject:    "mySessionMe",
-			// 				Issuer:     "https://127.0.0.1:8443",
-			// 				GivenName:  "Chris",
-			// 				FamilyName: "Burkert",
-			// 			}, nil)
-			// 	},
-			// 	wantError: false,
-			// 	wantCode:  rpc.UNAUTHENTICATED,
-			// }, {
+			name:         "with malformed CSRF token",
+			featureGates: defaultFeatureGates,
+			request: &envoyauth.CheckRequest{
+				Attributes: &envoyauth.AttributeContext{
+					Request: &envoyauth.AttributeContext_Request{
+						Http: &envoyauth.AttributeContext_HttpRequest{
+							Method:  "GET",
+							Host:    "our.service.com",
+							Path:    "/cmk/v1/myTenantID/bar",
+							Headers: map[string]string{"cookie": "__Host-Http-SESSION=" + sessionID, HeaderCSRFToken: "malformed CSRF token"}}}}},
+			setupMocks: func(msm *MockSessionManager) {
+				msm.On("GetSession", mock.Anything, "mySessionID", "myTenantID", mock.Anything).
+					Return(&session.Session{
+						Valid:      true,
+						Subject:    "mySessionMe",
+						Issuer:     "https://127.0.0.1:8443",
+						GivenName:  "Chris",
+						FamilyName: "Burkert",
+					}, nil)
+			},
+			wantError: false,
+			wantCode:  code.Code_UNAUTHENTICATED,
+		}, {
+			name:         "with malformed cookie",
+			featureGates: defaultFeatureGates,
+			request: &envoyauth.CheckRequest{
+				Attributes: &envoyauth.AttributeContext{
+					Request: &envoyauth.AttributeContext_Request{
+						Http: &envoyauth.AttributeContext_HttpRequest{
+							Method:  "GET",
+							Host:    "our.service.com",
+							Path:    "/cmk/v1/myTenantID/bar",
+							Headers: map[string]string{"cookie": "__Host-Http-SESSION=" + "malformedSessionID", HeaderCSRFToken: "malformed CSRF token"}}}}},
+			setupMocks: func(msm *MockSessionManager) {
+				msm.On("GetSession", mock.Anything, "malformedSessionID", "myTenantID", mock.Anything).
+					Return(&session.Session{
+						Valid:      true,
+						Subject:    "mySessionMe",
+						Issuer:     "https://127.0.0.1:8443",
+						GivenName:  "Chris",
+						FamilyName: "Burkert",
+					}, nil)
+			},
+			wantError: false,
+			wantCode:  code.Code_UNAUTHENTICATED,
+		}, {
 			name:            "registry service - system",
 			featureGates:    defaultFeatureGates,
 			trustedSubjects: map[string]string{"CN=minime": "minime-region"},


### PR DESCRIPTION
Ensure that an invalid CSRF token leads to the request being rejected.