### PR TITLE
fix(helm): make image.tag or image.digest mandatory

### DIFF
--- a/charts/extauthz/Chart.yaml
+++ b/charts/extauthz/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.6
+version: 0.13.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extauthz/templates/_helpers.tpl
+++ b/charts/extauthz/templates/_helpers.tpl
@@ -76,11 +76,12 @@ Create the name of the service account to use
 
 {{/*
 Util function for generating the image URL based on the provided options.
+Either image.tag or image.digest must be set explicitly; no fallback to appVersion.
 */}}
 {{- define "extauthz.image" -}}
-{{- $defaultTag := index . 1 -}}
 {{- with index . 0 -}}
+{{- if not (or .digest .tag) -}}{{ fail "Either image.tag or image.digest must be set" }}{{- end -}}
 {{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}
-{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
+{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" .tag }}{{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/extauthz/templates/deployment.yaml
+++ b/charts/extauthz/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ template "extauthz.image" (tuple .Values.image $.Chart.AppVersion) }}"
+          image: "{{ template "extauthz.image" (tuple .Values.image) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.image.args }}
           args:

--- a/charts/extauthz/values.yaml
+++ b/charts/extauthz/values.yaml
@@ -32,7 +32,7 @@ image:
 
   # Override the image tag to deploy by setting this variable.
   # +docs:property
-  tag: latest
+  tag: ""
 
   # Setting a digest will override any tag.
   # +docs:property

--- a/charts/extauthz/values.yaml
+++ b/charts/extauthz/values.yaml
@@ -31,9 +31,8 @@ image:
   repository: images/checker
 
   # Override the image tag to deploy by setting this variable.
-  # If no value is set, the chart's appVersion is used.
   # +docs:property
-  tag: ""
+  tag: latest
 
   # Setting a digest will override any tag.
   # +docs:property

--- a/helm-tests/unit/deployment_test.go
+++ b/helm-tests/unit/deployment_test.go
@@ -76,6 +76,12 @@ func TestDeployment(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Arrange
+			if tc.opts.SetValues == nil {
+				tc.opts.SetValues = map[string]string{}
+			}
+			tc.opts.SetValues["image.tag"] = "foo"
+
 			// Act
 			got, err := helm.RenderTemplateE(t, tc.opts, path, appName, []string{yamlFile})
 

--- a/helm-tests/unit/hpa_test.go
+++ b/helm-tests/unit/hpa_test.go
@@ -74,6 +74,12 @@ func TestHorizontalPodAutoscaler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Arrange
+			if tc.opts.SetValues == nil {
+				tc.opts.SetValues = map[string]string{}
+			}
+			tc.opts.SetValues["image.tag"] = "foo"
+
 			// Act
 			got, err := helm.RenderTemplateE(t, tc.opts, path, appName, []string{yamlFile})
 

--- a/helm-tests/unit/pdb_test.go
+++ b/helm-tests/unit/pdb_test.go
@@ -87,6 +87,12 @@ func TestPodDisruptionBudget(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Arrange
+			if tc.opts.SetValues == nil {
+				tc.opts.SetValues = map[string]string{}
+			}
+			tc.opts.SetValues["image.tag"] = "foo"
+
 			// Act
 			got, err := helm.RenderTemplateE(t, tc.opts, path, appName, []string{yamlFile})
 

--- a/helm-tests/unit/service_test.go
+++ b/helm-tests/unit/service_test.go
@@ -68,6 +68,12 @@ func TestService(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Arrange
+			if tc.opts.SetValues == nil {
+				tc.opts.SetValues = map[string]string{}
+			}
+			tc.opts.SetValues["image.tag"] = "foo"
+
 			// Act
 			got, err := helm.RenderTemplateE(t, tc.opts, path, appName, []string{yamlFile})
 

--- a/helm-tests/unit/serviceaccount_test.go
+++ b/helm-tests/unit/serviceaccount_test.go
@@ -56,6 +56,12 @@ func TestServiceAccount(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Arrange
+			if tc.opts.SetValues == nil {
+				tc.opts.SetValues = map[string]string{}
+			}
+			tc.opts.SetValues["image.tag"] = "foo"
+
 			// Act
 			got, err := helm.RenderTemplateE(t, tc.opts, path, appName, []string{yamlFile})
 


### PR DESCRIPTION
## Summary
- Removes the silent fallback to `appVersion` in the image helper
- Deployments without an explicit `image.tag` or `image.digest` now fail at render time with a clear error instead of silently using whatever `appVersion` is set to
- If both `image.tag` and `image.digest` are provided, digest takes precedence (unchanged behaviour)
- Bumps chart patch version