### PR TITLE
fix: cedar request handling and policy configuration

### DIFF
--- a/internal/policies/cedarpolicy/check.go
+++ b/internal/policies/cedarpolicy/check.go
@@ -13,14 +13,29 @@ var (
 	ErrUnexpectedPolicyEngine = errors.New("unexpected policy engine type")
 )
 
+// request represents an authorization request being constructed.
+// It implements the Engine interface but panics on Check() since
+// it's only meant to be configured, not executed.
+type request struct {
+	principal cedar.EntityUID
+	action    cedar.EntityUID
+	resource  cedar.EntityUID
+	context   cedar.Record
+}
+
+// Check implements Engine interface but panics - request is not an engine.
+func (r *request) Check(opts ...policies.CheckOption) (bool, string, error) {
+	panic("request.Check should never be called - request is for building, not executing")
+}
+
 func WithSubject(subject string) policies.CheckOption {
 	return func(d policies.Engine) error {
-		cpe, ok := d.(*cedarPolicyEngine)
+		req, ok := d.(*request)
 		if !ok {
 			return ErrUnexpectedPolicyEngine
 		}
 
-		cpe.request.Principal = cedar.NewEntityUID("Subject", cedar.String(subject))
+		req.principal = cedar.NewEntityUID("Subject", cedar.String(subject))
 
 		return nil
 	}
@@ -28,12 +43,12 @@ func WithSubject(subject string) policies.CheckOption {
 
 func WithAction(action string) policies.CheckOption {
 	return func(d policies.Engine) error {
-		cpe, ok := d.(*cedarPolicyEngine)
+		req, ok := d.(*request)
 		if !ok {
 			return ErrUnexpectedPolicyEngine
 		}
 
-		cpe.request.Action = cedar.NewEntityUID("Action", cedar.String(action))
+		req.action = cedar.NewEntityUID("Action", cedar.String(action))
 
 		return nil
 	}
@@ -41,7 +56,7 @@ func WithAction(action string) policies.CheckOption {
 
 func WithContextData(data map[string]string) policies.CheckOption {
 	return func(d policies.Engine) error {
-		cpe, ok := d.(*cedarPolicyEngine)
+		req, ok := d.(*request)
 		if !ok {
 			return ErrUnexpectedPolicyEngine
 		}
@@ -51,28 +66,35 @@ func WithContextData(data map[string]string) policies.CheckOption {
 			cedarContext[cedar.String(k)] = cedar.String(v)
 		}
 
-		cpe.request.Context = cedar.NewRecord(cedarContext)
+		req.context = cedar.NewRecord(cedarContext)
 
 		return nil
 	}
 }
 
 func (e *cedarPolicyEngine) Check(opts ...policies.CheckOption) (bool, string, error) {
-	cpe := &cedarPolicyEngine{
-		request: cedar.Request{},
-	}
+	req := &request{}
+
 	for _, opt := range opts {
 		if opt == nil {
 			continue
 		}
-		err := opt(cpe)
+
+		err := opt(req)
 		if err != nil {
 			return false, "", err
 		}
 	}
 
+	cedarReq := cedar.Request{
+		Principal: req.principal,
+		Action:    req.action,
+		Resource:  req.resource,
+		Context:   req.context,
+	}
+
 	// call the cedar engine
-	decision, diagnostic := cedar.Authorize(e.policySet, nil, cpe.request)
+	decision, diagnostic := cedar.Authorize(e.policySet, nil, cedarReq)
 
 	// marshal the diagnostic
 	diagnosticBytes, err := json.Marshal(diagnostic)

--- a/internal/policies/cedarpolicy/engine.go
+++ b/internal/policies/cedarpolicy/engine.go
@@ -9,8 +9,6 @@ import (
 )
 
 type cedarPolicyEngine struct {
-	request cedar.Request
-
 	policySet *cedar.PolicySet
 }
 


### PR DESCRIPTION
### Summary

Successfully fixed the Cedar policy engine architectural flaw by separating request configuration from engine state.

### Problem Identified

The original implementation had a confusing and dangerous pattern:
- `Check()` created a temporary `cedarPolicyEngine` instance
- Option closures (`WithSubject`, `WithAction`, `WithContextData`) type-asserted and mutated the **temporary** engine's request field
- The actual authorization used `e.policySet` from the **receiver** and `cpe.request` from the **temporary** engine
- This only worked because current options don't read receiver state
- Future options (e.g., `WithResource`) could silently read from the wrong engine

### Solution Implemented

Created a dedicated `request` type for building authorization requests:

1. **Added `request` type** in `internal/policies/cedarpolicy/check.go`:
   - Implements `Engine` interface (required by `CheckOption` signature)
   - Panics if `Check()` is called (fail-fast for misuse)
   - Contains fields: `principal`, `action`, `resource`, `context`

2. **Updated option functions** to type-assert to `*request`:
   - `WithSubject`: mutates `req.principal` instead of `cpe.request.Principal`
   - `WithAction`: mutates `req.action` instead of `cpe.request.Action`
   - `WithContextData`: mutates `req.context` instead of `cpe.request.Context`

3. **Updated `Check()` method**:
   - Creates `&request{}` instead of temporary `&cedarPolicyEngine{}`
   - Applies options to build the request
   - Constructs `cedar.Request` from the built request
   - Uses receiver's `e.policySet` with the properly-constructed request

4. **Removed unused field** from `cedarPolicyEngine`:
   - Removed `request cedar.Request` field (line 12 in engine.go)
   - Engine now only stores `policySet` — the persistent configuration