### PR TITLE
fix: Remove browser fingerprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/jellydator/ttlcache/v3 v3.4.0
-	github.com/openkcm/api-sdk v0.18.0
+	github.com/openkcm/api-sdk v0.18.1
 	github.com/openkcm/common-sdk v1.16.1
 	github.com/samber/oops v1.22.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openkcm/api-sdk v0.18.0 h1:bLURye5GkxSM9SqT3ji94A9HgI9/KgHKFTNgnIeSRWk=
-github.com/openkcm/api-sdk v0.18.0/go.mod h1:3CQUZVNl/Nu5K71M1arSiTsJhyLloO3pJpqwBL1oE1o=
+github.com/openkcm/api-sdk v0.18.1 h1:Ch8iPTKz/PAgHI1HVHeYHKT8iuKjb5jHHRJoPl10HiM=
+github.com/openkcm/api-sdk v0.18.1/go.mod h1:3CQUZVNl/Nu5K71M1arSiTsJhyLloO3pJpqwBL1oE1o=
 github.com/openkcm/common-sdk v1.16.1 h1:0GIFrEDR7qXj/ghSvwWVHnWCAzBGD7iFbdRN4WWv9tM=
 github.com/openkcm/common-sdk v1.16.1/go.mod h1:2UuIjhOuee6gQKJt3EnenhB8mXWriGHEXdxCGPWfRxw=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/internal/extauthz/check.go
+++ b/internal/extauthz/check.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/openkcm/common-sdk/pkg/auth"
-	"github.com/openkcm/common-sdk/pkg/fingerprint"
 
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
@@ -94,12 +93,12 @@ func (srv *Server) Check(ctx context.Context, req *envoyauth.CheckRequest) (*env
 	// 3. Session cookie (if any and only if session manager is configured)
 	if srv.sessionManager != nil {
 		slogctx.Debug(ctx, LogPrefixSessionCookie+"checking for presence")
-		if sessionCookie, tenantID, fingerPrint, found := srv.extractSessionDetails(ctx, httpreq, path); !found {
+		if sessionCookie, tenantID, found := srv.extractSessionDetails(ctx, httpreq, path); !found {
 			slogctx.Debug(ctx, LogPrefixSessionCookie+"not found")
 		} else {
 			slogctx.Debug(ctx, LogPrefixSessionCookie+"found ... checking")
 			csrfToken := headers[HeaderCSRFToken]
-			r := srv.checkSession(ctx, sessionCookie, tenantID, fingerPrint, method, host, path, csrfToken)
+			r := srv.checkSession(ctx, sessionCookie, tenantID, method, host, path, csrfToken)
 			slogctx.Debug(ctx, LogPrefixSessionCookie+"access "+r.is.String())
 			result.merge(r)
 		}
@@ -192,24 +191,24 @@ func (srv *Server) extractTenantID(path string) string {
 	return ""
 }
 
-func (srv *Server) extractSessionDetails(ctx context.Context, httpreq *envoyauth.AttributeContext_HttpRequest, path string) (*http.Cookie, string, string, bool) {
+func (srv *Server) extractSessionDetails(ctx context.Context, httpreq *envoyauth.AttributeContext_HttpRequest, path string) (*http.Cookie, string, bool) {
 	headers := httpreq.GetHeaders()
 	tenantID := srv.extractTenantID(path)
 	if tenantID == "" {
 		slogctx.Debug(ctx, LogPrefixSessionCookie+"failed to extract tenant ID from path", "sessionPathPrefixes", srv.sessionPathPrefixes)
-		return nil, "", "", false
+		return nil, "", false
 	}
 
 	// extract the tenant specific session cookie
 	cookieHeader, found := headers[HeaderCookie]
 	if !found {
 		slogctx.Debug(ctx, LogPrefixSessionCookie+"no cookie header found", "headers", mapKeys(headers))
-		return nil, "", "", false
+		return nil, "", false
 	}
 	cookies, err := http.ParseCookie(cookieHeader)
 	if err != nil {
 		slogctx.Debug(ctx, LogPrefixSessionCookie+"failed to parse cookie header", "error", err)
-		return nil, "", "", false
+		return nil, "", false
 	}
 	sessionCookieName := SessionCookiePrefix + tenantID
 	var sessionCookie *http.Cookie
@@ -224,17 +223,10 @@ func (srv *Server) extractSessionDetails(ctx context.Context, httpreq *envoyauth
 	// return if no session cookie found
 	if sessionCookie == nil {
 		slogctx.Debug(ctx, LogPrefixSessionCookie+"tenant specific session cookie not found", "name", sessionCookieName)
-		return nil, "", "", false
+		return nil, "", false
 	}
 
-	// determine the fingerprint for the request
-	fp, err := fingerprint.NewBuilder().FromEnvoyHTTPRequest(httpreq)
-	if err != nil {
-		slogctx.Debug(ctx, LogPrefixSessionCookie+"failed to compute fingerprint from request", "error", err)
-		return nil, "", "", false
-	}
-
-	return sessionCookie, tenantID, fp, true
+	return sessionCookie, tenantID, true
 }
 
 // splitCertHeader splits the XFCC header on , in case there are multiple certificates.

--- a/internal/extauthz/check_session.go
+++ b/internal/extauthz/check_session.go
@@ -16,7 +16,7 @@ import (
 )
 
 // checkSession checks the request using the session Cookie.
-func (srv *Server) checkSession(ctx context.Context, sessionCookie *http.Cookie, tenantID, fingerprint, method, host, path, csrfToken string) checkResult {
+func (srv *Server) checkSession(ctx context.Context, sessionCookie *http.Cookie, tenantID, method, host, path, csrfToken string) checkResult {
 	if sessionCookie == nil {
 		slogctx.Debug(ctx, "Session cookie is nil")
 		return checkResult{is: UNKNOWN}
@@ -24,10 +24,9 @@ func (srv *Server) checkSession(ctx context.Context, sessionCookie *http.Cookie,
 
 	// On GetSession the session manager will:
 	// - check if the session exists for this session ID and tenant ID
-	// - compare the fingerprints
 	// - validate the session (expiry, token revocation, ...)
 	// If the session is valid, it will return the session details.
-	sess, err := srv.sessionManager.GetSession(ctx, sessionCookie.Value, tenantID, fingerprint)
+	sess, err := srv.sessionManager.GetSession(ctx, sessionCookie.Value, tenantID)
 	if err != nil {
 		if errors.Is(err, session.ErrTenantBlocked) {
 			return checkResult{is: TENANT_BLOCKED, info: fmt.Sprintf("the tenant %s is blocked", tenantID)}

--- a/internal/extauthz/check_session_test.go
+++ b/internal/extauthz/check_session_test.go
@@ -22,8 +22,8 @@ type MockSessionManager struct {
 	mock.Mock
 }
 
-func (m *MockSessionManager) GetSession(ctx context.Context, sessionID, tenantID, fingerprint string) (*session.Session, error) {
-	args := m.Called(ctx, sessionID, tenantID, fingerprint)
+func (m *MockSessionManager) GetSession(ctx context.Context, sessionID, tenantID string) (*session.Session, error) {
+	args := m.Called(ctx, sessionID, tenantID)
 	if args.Get(0) == nil {
 		return &session.Session{}, args.Error(1)
 	}
@@ -41,7 +41,6 @@ func TestCheckSession(t *testing.T) {
 		name           string
 		cookie         *http.Cookie
 		tenantID       string
-		fingerprint    string
 		method         string
 		host           string
 		path           string
@@ -57,7 +56,7 @@ func TestCheckSession(t *testing.T) {
 			cookie:    &http.Cookie{Name: "session", Value: sessionID},
 			csrfToken: csrfToken,
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything).
 					Return(nil, errors.New("get session error"))
 			},
 			expectedResult: checkResult{is: UNAUTHENTICATED},
@@ -66,7 +65,7 @@ func TestCheckSession(t *testing.T) {
 			cookie:    &http.Cookie{Name: "session", Value: sessionID},
 			csrfToken: csrfToken,
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything).
 					Return(&session.Session{Valid: false}, nil)
 			},
 			expectedResult: checkResult{is: UNAUTHENTICATED},
@@ -78,7 +77,7 @@ func TestCheckSession(t *testing.T) {
 			path:      "/foo/bar",
 			csrfToken: csrfToken,
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, "", "").
+				sm.On("GetSession", mock.Anything, mock.Anything, "").
 					Return(&session.Session{
 						Valid:   true,
 						Subject: "me",
@@ -94,7 +93,7 @@ func TestCheckSession(t *testing.T) {
 			path:      "/foo/bar",
 			csrfToken: "malformed csrf token",
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, "", "").
+				sm.On("GetSession", mock.Anything, mock.Anything, "").
 					Return(&session.Session{
 						Valid:   true,
 						Subject: "me",
@@ -107,7 +106,7 @@ func TestCheckSession(t *testing.T) {
 			cookie:    &http.Cookie{Name: "session", Value: sessionID},
 			csrfToken: csrfToken,
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything).
 					Return(&session.Session{Valid: true}, nil)
 			},
 			expectedResult: checkResult{is: DENIED},
@@ -119,7 +118,7 @@ func TestCheckSession(t *testing.T) {
 			path:      "/foo/bar",
 			csrfToken: csrfToken,
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything).
 					Return(&session.Session{
 						Valid:   true,
 						Subject: "me",
@@ -135,7 +134,7 @@ func TestCheckSession(t *testing.T) {
 			path:      "/foo/bar",
 			csrfToken: csrfToken,
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything).
 					Return(&session.Session{
 						Valid:   true,
 						Subject: "me",
@@ -151,7 +150,7 @@ func TestCheckSession(t *testing.T) {
 			path:      "/foo/baz",
 			csrfToken: csrfToken,
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything).
 					Return(&session.Session{
 						Valid:   true,
 						Subject: "me",
@@ -167,7 +166,7 @@ func TestCheckSession(t *testing.T) {
 			path:      "/foo/bar",
 			csrfToken: csrfToken,
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything).
 					Return(&session.Session{
 						Valid:   true,
 						Subject: "me",
@@ -185,7 +184,7 @@ func TestCheckSession(t *testing.T) {
 			csrfToken: csrfToken,
 			tenantID:  "t-id",
 			setupMocks: func(sm *MockSessionManager) {
-				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				sm.On("GetSession", mock.Anything, mock.Anything, mock.Anything).
 					Return(nil, session.ErrTenantBlocked)
 			},
 			expectedResult: checkResult{is: TENANT_BLOCKED, info: "the tenant t-id is blocked"},
@@ -224,7 +223,7 @@ func TestCheckSession(t *testing.T) {
 			}
 
 			// Act
-			result := srv.checkSession(ctx, tc.cookie, tc.tenantID, tc.fingerprint, tc.method, tc.host, tc.path, tc.csrfToken)
+			result := srv.checkSession(ctx, tc.cookie, tc.tenantID, tc.method, tc.host, tc.path, tc.csrfToken)
 
 			// Assert
 			assert.Equal(t, tc.expectedResult.is, result.is)

--- a/internal/extauthz/extauthz.go
+++ b/internal/extauthz/extauthz.go
@@ -32,7 +32,7 @@ const (
 // sessionManagerInterface defines the interface for the session manager.
 // We don't use session.Manager directly to make testing easier.
 type sessionManagerInterface interface {
-	GetSession(ctx context.Context, sessionID, tenantID, fingerprint string) (*session.Session, error)
+	GetSession(ctx context.Context, sessionID, tenantID string) (*session.Session, error)
 }
 
 // oidcHandlerInterface defines the interface for OIDC handling.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -37,11 +37,10 @@ func NewManager(grpcConn *grpc.ClientConn, opts ...ManagerOption) (*Manager, err
 	return m, nil
 }
 
-func (m *Manager) GetSession(ctx context.Context, sessionID, tenantID, fingerprint string) (*Session, error) {
+func (m *Manager) GetSession(ctx context.Context, sessionID, tenantID string) (*Session, error) {
 	getSessionRequest := &sessionv1.GetSessionRequest{
-		SessionId:   sessionID,
-		TenantId:    tenantID,
-		Fingerprint: fingerprint,
+		SessionId: sessionID,
+		TenantId:  tenantID,
 	}
 	resp, err := m.grpcClient.GetSession(ctx, getSessionRequest)
 	if err != nil {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -88,13 +88,12 @@ func TestNewManager(t *testing.T) {
 func TestGetSession(t *testing.T) {
 	// create the test cases
 	tests := []struct {
-		name        string
-		sessionID   string
-		tenantID    string
-		fingerprint string
-		expected    *Session
-		wantErr     bool
-		setupMocks  func(*SessionManagerMock)
+		name       string
+		sessionID  string
+		tenantID   string
+		expected   *Session
+		wantErr    bool
+		setupMocks func(*SessionManagerMock)
 	}{
 		{
 			name: "valid session",
@@ -148,7 +147,7 @@ func TestGetSession(t *testing.T) {
 			}
 
 			// Act
-			got, err := manager.GetSession(t.Context(), tc.sessionID, tc.tenantID, tc.fingerprint)
+			got, err := manager.GetSession(t.Context(), tc.sessionID, tc.tenantID)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("Manager.GetSession() return an unexpected error %v", err)
 			}


### PR DESCRIPTION
fix: Deprecate browser fingerprint.
The current fingerprinting implementation is not beneficial and should be removed.