### PR TITLE
chore(lint): declare integration build tag and fix lint issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ version: "2"
 run:
   concurrency: 4
   timeout: 10m
+  build-tags: ["integration"]
 
 linters:
   default: all

--- a/integration/grpc_server_test.go
+++ b/integration/grpc_server_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
-	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 )
 
 func TestCheck(t *testing.T) {
@@ -25,17 +26,18 @@ func TestCheck(t *testing.T) {
 	defer cleanup()
 
 	// start the service in the background
-	cmd := exec.Command("./"+binary, "--graceful-shutdown=0")
+	cmd := exec.CommandContext(t.Context(), "./"+binary, "--graceful-shutdown=0")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err = cmd.Start(); err != nil {
+	err = cmd.Start()
+	if err != nil {
 		t.Fatalf("could not start command: %s", err)
 	}
 	// defer the graceful stop of the service so that coverprofiles are written
 	defer func() {
-		syscall.Kill(cmd.Process.Pid, syscall.SIGTERM)
-		cmd.Wait()
+		_ = syscall.Kill(cmd.Process.Pid, syscall.SIGTERM)
+		_ = cmd.Wait()
 		t.Logf("Stdout: %s\n", stdout.String())
 		t.Logf("Stderr: %s\n", stderr.String())
 	}()
@@ -67,7 +69,8 @@ func TestCheck(t *testing.T) {
 		if i < 1 {
 			t.Fatalf("could not connect to server: %s", err)
 		}
-		if _, err := client.Check(t.Context(), nil); err == nil {
+		_, checkErr := client.Check(t.Context(), nil)
+		if checkErr == nil {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -86,9 +86,10 @@ func writeFiles(config, trustedSubjects, policies, rsaPrivateKeyPEM string) (fun
 
 	// write the files and remember them for later cleanup
 	for file, content := range files {
-		if err := os.WriteFile(file, []byte(content), 0640); err != nil {
+		err := os.WriteFile(file, []byte(content), 0640)
+		if err != nil {
 			cleanupFunc() // clean up any files written before the error
-			return nil, fmt.Errorf("could not write file: %v, got: %s", file, err)
+			return nil, fmt.Errorf("could not write file: %v, got: %w", file, err)
 		}
 		cleanupFiles = append(cleanupFiles, file)
 	}
@@ -103,7 +104,8 @@ func buildCommandsAndRunTests(m *testing.M, cmds ...string) int {
 		log.Fatalf("error starting valkey container: %v", err)
 	}
 	defer func() {
-		if err := testcontainers.TerminateContainer(valkeyContainer); err != nil {
+		err := testcontainers.TerminateContainer(valkeyContainer)
+		if err != nil {
 			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
@@ -113,8 +115,9 @@ func buildCommandsAndRunTests(m *testing.M, cmds ...string) int {
 
 	// build the commands to be tested
 	for _, name := range cmds {
-		cmd := exec.Command("go", "build", "-buildvcs=false", "-race", "-cover", "-o", name, "../cmd/"+name)
-		if output, err := cmd.CombinedOutput(); err != nil {
+		cmd := exec.CommandContext(context.Background(), "go", "build", "-buildvcs=false", "-race", "-cover", "-o", name, "../cmd/"+name)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
 			log.Printf("output: %s", output)
 			log.Fatalf("error: %v", err)
 		}
@@ -142,15 +145,15 @@ func startValkeyContainer() (*tcvalkey.ValkeyContainer, string, error) {
 		tcvalkey.WithLogLevel(tcvalkey.LogLevelVerbose),
 	)
 	if err != nil {
-		return nil, "", fmt.Errorf("error starting valkey container: %v", err)
+		return nil, "", fmt.Errorf("error starting valkey container: %w", err)
 	}
 	connstr, err := valkeyContainer.ConnectionString(ctx)
 	if err != nil {
-		return nil, "", fmt.Errorf("error getting valkey container connection string: %v", err)
+		return nil, "", fmt.Errorf("error getting valkey container connection string: %w", err)
 	}
 	uri, err := url.Parse(connstr)
 	if err != nil {
-		return nil, "", fmt.Errorf("error parsing valkey container connection string: %v", err)
+		return nil, "", fmt.Errorf("error parsing valkey container connection string: %w", err)
 	}
 
 	return valkeyContainer, uri.Host, nil

--- a/integration/status_server_test.go
+++ b/integration/status_server_test.go
@@ -22,17 +22,18 @@ func TestStatusServer(t *testing.T) {
 	defer cleanup()
 
 	// start the service in the background
-	cmd := exec.Command("./"+binary, "--graceful-shutdown=0")
+	cmd := exec.CommandContext(t.Context(), "./"+binary, "--graceful-shutdown=0")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err = cmd.Start(); err != nil {
+	err = cmd.Start()
+	if err != nil {
 		t.Fatalf("could not start command: %s", err)
 	}
 	// defer the graceful stop of the service so that coverprofiles are written
 	defer func() {
-		syscall.Kill(cmd.Process.Pid, syscall.SIGTERM)
-		cmd.Wait()
+		_ = syscall.Kill(cmd.Process.Pid, syscall.SIGTERM)
+		_ = cmd.Wait()
 		t.Logf("Stdout: %s", stdout.String())
 		t.Logf("Stderr: %s", stderr.String())
 	}()
@@ -67,7 +68,13 @@ func TestStatusServer(t *testing.T) {
 		if i < 1 {
 			t.Fatalf("could not connect to server: %s", err)
 		}
-		if _, err := http.Get("http://localhost:8080/"); err == nil {
+		req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost:8080/", nil)
+		if reqErr != nil {
+			t.Fatalf("could not build request: %s", reqErr)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -77,7 +84,11 @@ func TestStatusServer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Act
-			resp, err := http.Get("http://localhost:8080/" + tc.endpoint)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost:8080/"+tc.endpoint, nil)
+			if err != nil {
+				t.Fatalf("could not build request: %s", err)
+			}
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				t.Fatalf("could not send request: %s", err)
 			}

--- a/integration/version_test.go
+++ b/integration/version_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestVersion(t *testing.T) {
 	// Arrange
-	cmd := exec.Command("./"+binary, "-version")
+	cmd := exec.CommandContext(t.Context(), "./"+binary, "-version")
 
 	// Act
 	err := cmd.Run()


### PR DESCRIPTION
**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
Adding the `integration` build tag under golangci-lint's `run.build-tags` makes the linter also scan the integration test files. Fix the issues it reported so `make lint` stays clean.
```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
NONE
```
