### PR TITLE
fix: cancel context on ServerOption failure in NewServer

### DIFF
--- a/internal/extauthz/extauthz.go
+++ b/internal/extauthz/extauthz.go
@@ -265,6 +265,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		}
 		err := opt(server)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
 	}


### PR DESCRIPTION
If a ServerOption returned an error, the context created for the OIDC handler was never cancelled. This left the handler's background goroutines (ttlcache) running indefinitely with an uncancelled context.

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.

```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
