### PR TITLE
Fix/grpc connection leak

### DIFF
--- a/internal/extauthz/extauthz.go
+++ b/internal/extauthz/extauthz.go
@@ -313,5 +313,12 @@ func (s *Server) Close() error {
 		_ = s.rateStore.Close()
 	}
 
+	if closer, ok := s.sessionManager.(interface{ Close() error }); ok {
+		err := closer.Close()
+		if err != nil {
+			return oops.Hint("failed to close session manager gRPC connection").Wrap(err)
+		}
+	}
+
 	return nil
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -40,6 +40,10 @@ func NewManager(grpcConn *grpc.ClientConn, opts ...ManagerOption) (*Manager, err
 	return m, nil
 }
 
+func (m *Manager) Close() error {
+	return m.grpcConn.Close()
+}
+
 func (m *Manager) GetSession(ctx context.Context, sessionID, tenantID string) (*Session, error) {
 	getSessionRequest := &sessionv1.GetSessionRequest{
 		SessionId: sessionID,


### PR DESCRIPTION
session.Manager held a *grpc.ClientConn but never closed it on shutdown. Add a Close() method to Manager and call it via type assertion in Server.Close() so the sessionManagerInterface does not need changing (existing mocks remain unaffected).

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.

```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
