### PR TITLE
fix: set correct auth type label for session in Cedar policy context

### DIFF
--- a/examples/policies.cedar
+++ b/examples/policies.cedar
@@ -36,3 +36,16 @@ permit (
 	context.path like "/cmk/*" &&
 	context.issuer == "https://iam.myorg.com/"
 };
+
+/////////////////////////////////////////
+// Users based on session cookie accessing the CMK Backend via the CMK UI
+permit (
+	principal is Subject,
+	action in [Action::"GET", Action::"POST"],
+	resource
+) when {
+	context.type == "session" &&
+	context.host == "myorg.com" &&
+	context.path like "/cmk/*" &&
+	context.issuer like "*"
+};

--- a/internal/extauthz/check_session.go
+++ b/internal/extauthz/check_session.go
@@ -80,7 +80,7 @@ func (srv *Server) checkSession(ctx context.Context, sessionCookie *http.Cookie,
 	data := map[string]string{
 		contextKeyHost:   req.host,
 		contextKeyPath:   req.path,
-		contextKeyType:   authTypeJWT,
+		contextKeyType:   authTypeSession,
 		contextKeyIssuer: sess.Issuer,
 	}
 

--- a/internal/extauthz/extauthz.go
+++ b/internal/extauthz/extauthz.go
@@ -36,8 +36,9 @@ const (
 	contextKeyIssuer = "issuer"
 
 	// Auth type values
-	authTypeX509 = "x509"
-	authTypeJWT  = "jwt"
+	authTypeX509    = "x509"
+	authTypeJWT     = "jwt"
+	authTypeSession = "session"
 )
 
 // sessionManagerInterface defines the interface for the session manager.


### PR DESCRIPTION
## Summary

- Fixes `check_session.go` to pass `context.type == "session"` to the Cedar policy engine for session-authenticated requests (was incorrectly passing `"jwt"`)
- Adds `authTypeSession` constant to `extauthz.go`
- Updates `examples/policies.cedar` to document the session permit rule alongside `x509` and `jwt` examples, including `context.issuer like "*"` as a defensive existence check matching the JWT rule posture

## Problem

`check_session.go` was building the Cedar context with `contextKeyType: authTypeJWT` for session requests. This meant session users were silently permitted by the JWT Cedar rule rather than an explicit session rule — making the two indistinguishable at the policy layer. Once the correct `"session"` type is passed, session requests will no longer match the JWT rule.

## Linked PR

infra ConfigMap change (adds the `session` Cedar permit rule to all regional clusters): https://github.tools.sap/kms/infra/pull/2858

**Deployment note:** The infra ConfigMap change (kms/infra#2858) is backward compatible with extauthz, however the new extauthz in not compatible with the old ConfigMap. Therefore, the infra PR should be merged and the reloader must have cycled the extauthz pods with the new ConfigMap before this fix (the new extauthz image) is deployed. See the infra PR for full deployment sequencing requirements.